### PR TITLE
Ajuste del Host Mailer para el envio de correos

### DIFF
--- a/services/mailer.js
+++ b/services/mailer.js
@@ -39,7 +39,7 @@ function createTransport() {
       });*/
 
   return nodemailer.createTransport({
-    service: 'Mailgun',
+    host: process.env.SMTP_HOST,
     auth: {
       user: process.env.SMTP_USER,
       pass: process.env.SMTP_PASSWORD


### PR DESCRIPTION
Originalmente se encontraba planteado para utilizar el servicio de Mailgun. De esta forma se deja como variable de entorno para seleccionar el servicio SMTP indicado.